### PR TITLE
Fix a bug where if the SendToDiscord method is called with an empty a…

### DIFF
--- a/discord-webhook-client/DiscordWebhookClient.cs
+++ b/discord-webhook-client/DiscordWebhookClient.cs
@@ -94,7 +94,10 @@ namespace JNogueira.Discord.Webhook.Client
             try
             {
                 if (files == null || files.Length == 0)
+                {
                     await SendToDiscord(message);
+                    return;
+                }
 
                 if (files.Length > 10)
                     throw new DiscordWebhookClientException($"Files collection size limit is 10 objects. (actual size is {files.Length})");


### PR DESCRIPTION
Fix a bug where if the method SendToDiscord is called with an empty array of files, the message is sent twice to the client